### PR TITLE
Resolves primary key integer error

### DIFF
--- a/tests/test_aisparser.py
+++ b/tests/test_aisparser.py
@@ -1,10 +1,7 @@
 from pyrate.algorithms.aisparser import run, AIS_CSV_COLUMNS, readcsv
-from utilities import setup_database
 from pyrate.repositories.aisdb import AISdb
 from pyrate.repositories import file
-from pyrate.algorithms.aisparser import run, AIS_CSV_COLUMNS
 from utilities import setup_database
-import logging
 import os
 import tempfile
 from pytest import fixture


### PR DESCRIPTION
Solves issue #40.
- Added update function to aisdb repository module to update existing tables (use `pyrate aisdb update` from the command line)
- Changed datatypes for id columns in ais_clean and ais_dirty tables to BISERIAL
- Removed duplicate imports in tests
